### PR TITLE
some enhancements

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,10 @@
 require './run'
 
 set :environment, ENV['RACK_ENV'].to_sym
+
+# this line is needed if you run this app behind a transparent proxy
+# set :protection, :except => [:http_origin]
+
 set :app_file, 'run.rb'
 disable :run
 
@@ -9,3 +13,4 @@ STDOUT.reopen(log)
 STDERR.reopen(log)
 
 run Sinatra::Application
+

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -6,6 +6,15 @@ module MailConfig
 	DB_PASS = ""
 	DB_DB = "mailserver"
 	
+	TABLE_ADMINS  = "domain_admins"
+	TABLE_USERS   = "virtual_users"
+	TABLE_DOMAINS = "virtual_domains"
+	TABLE_ALIASES = "virtual_aliases"
+  
+	HTTP_SCHEME = 'http'
+	HTTP_HOST   = 'localhost'
+	HTTP_PORT   = 4567
+	
 # If you're going to use the built-in autoresponder, this should return a
 # user's maildir mailbox when %u is replaced with their username, and %d with
 # the domain

--- a/lib/mailadmin.rb
+++ b/lib/mailadmin.rb
@@ -66,7 +66,14 @@ helpers do
       else
         port = ":#{request.port}"
       end
-      base = "#{request.scheme}://#{request.host}#{port}#{request.script_name}"
+      
+      if (! (MailConfig::HTTP_HOST && MailConfig::HTTP_SCHEME))
+        base = "#{request.scheme}://#{request.host}#{port}#{request.script_name}"
+      else
+        port = MailConfig::HTTP_PORT ? ":%d" % [ MailConfig::HTTP_PORT ] : port
+        base = "%s://%s%s%s" % [MailConfig::HTTP_SCHEME, MailConfig::HTTP_HOST, port, request.script_name]
+      end
+      
     else
       raise "Unknown script_url mode #{mode}"
     end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -9,7 +9,6 @@
 		<!--[If lt IE 9]>
 			<link rel="stylesheet" type="text/css" href="<%= link_to '/css/ie.css' %>"/>
 		<![EndIf]-->
-		<script type="text/javascript" src="<%= link_to '/js/datepickr.js' %>"></script>
 		<script type="text/javascript" src="<%= link_to '/js/util.js' %>"></script>
 		<link rel="shortcut icon" href="<%= link_to '/images/email_open_image.png' %>" type="image/x-icon" />
 	</head>


### PR DESCRIPTION
Hi, I set up my server using amavis-mysql. It's not possible to map table names in amavis, and I need them combined with the existing tables from Christoph Haas' tutorial. Also I need this app be run behind a proxy. 

In the next step I'll enhance the app to use amavis (>2.7). I want to make spam settings per domain or user configurable. It will be possible to define groups using the same bayes db. So it could also be interesting for you.
- allow to set main table names
- allow to force host, port, scheme in building links to allow using
  the app behind a transparent proxy
- added configuration hint for using this app behind a proxy to config.ru
- removed datepickr.js call, it's not available
